### PR TITLE
Use local React Native module instead of using the remote master branch

### DIFF
--- a/samples/ExtendedSample/package.json
+++ b/samples/ExtendedSample/package.json
@@ -10,7 +10,7 @@
 		"react": "16.2.0",
 		"react-native": "0.52",
 		"react-native-iphone-x-helper": "^1.0.2",
-		"react-native-scandit": "git+https://github.com/Scandit/barcodescanner-sdk-react-native.git",
+		"react-native-scandit": "file:../../",
 		"react-native-simple-events": "1.0.1",
 		"react-navigation": "github:react-community/react-navigation#master",
 		"react-navigation-is-focused-hoc": "^1.1.1"

--- a/samples/SimpleSample/package.json
+++ b/samples/SimpleSample/package.json
@@ -1,18 +1,18 @@
 {
-	"name": "SimpleSample",
-	"version": "5.7.0BETA1",
-	"private": true,
-	"scripts": {
-		"start": "node node_modules/react-native/local-cli/cli.js start",
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"dependencies": {
-		"react": "16.0.0-alpha.12",
-		"react-native": "0.47.1",
-		"react-native-scandit": "https://github.com/Scandit/barcodescanner-sdk-react-native.git"
-	},
-	"devDependencies": {
-		"babel-preset-react-native": "2.1.0",
-		"react-test-renderer": "16.0.0-alpha.12"
-	}
+    "name": "SimpleSample",
+    "version": "5.7.0BETA1",
+    "private": true,
+    "scripts": {
+        "start": "node node_modules/react-native/local-cli/cli.js start",
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "dependencies": {
+        "react": "16.0.0-alpha.12",
+        "react-native": "0.47.1",
+        "react-native-scandit": "file:../../"
+    },
+    "devDependencies": {
+        "babel-preset-react-native": "2.1.0",
+        "react-test-renderer": "16.0.0-alpha.12"
+    }
 }


### PR DESCRIPTION
if you want to run the samples for version 5.7 beta 1 you have to run `yarn install`. Currently, when you do `yarn install` it complains that it can't add react-native-scandit because the package version (5.8.0SNAPSHOT) is invalid. This is because in the package.json file we reference the master branch. Instead we should just reference the the downloaded version, so it will match the sample.