### PR TITLE
Fix camera switch visibility on tablet mode

### DIFF
--- a/samples/ExtendedSample/ios/ExtendedSample.xcodeproj/project.pbxproj
+++ b/samples/ExtendedSample/ios/ExtendedSample.xcodeproj/project.pbxproj
@@ -1136,6 +1136,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = ExtendedSample;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1158,6 +1159,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = ExtendedSample;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;


### PR DESCRIPTION
The camera switch's visibility was working correctly. The root cause was that the device was not recognized as a tablet by the SDK because the sample app was built in iPhone only mode, not Universal.
Switching it to Universal solved the issue.