### PR TITLE
fix/React Native 0.58 UIManager Warning

### DIFF
--- a/components/CommandDispatcher.js
+++ b/components/CommandDispatcher.js
@@ -10,120 +10,120 @@ export class CommandDispatcher {
 
   startScanning() {
     UIManager.dispatchViewManagerCommand(
-      this.pickerViewHandle, UIManager.BarcodePicker.Commands.startScanning, null);
+      this.pickerViewHandle, UIManager.getViewManagerConfig('BarcodePicker').Commands.startScanning, null);
   }
 
   stopScanning() {
     UIManager.dispatchViewManagerCommand(
-      this.pickerViewHandle, UIManager.BarcodePicker.Commands.stopScanning, null);
+      this.pickerViewHandle, UIManager.getViewManagerConfig('BarcodePicker').Commands.stopScanning, null);
   }
 
   resumeScanning() {
     UIManager.dispatchViewManagerCommand(
-      this.pickerViewHandle, UIManager.BarcodePicker.Commands.resumeScanning, null);
+      this.pickerViewHandle, UIManager.getViewManagerConfig('BarcodePicker').Commands.resumeScanning, null);
   }
 
   pauseScanning() {
     UIManager.dispatchViewManagerCommand(
-      this.pickerViewHandle, UIManager.BarcodePicker.Commands.pauseScanning, null);
+      this.pickerViewHandle, UIManager.getViewManagerConfig('BarcodePicker').Commands.pauseScanning, null);
   }
 
   applySettings(scanSettings) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.applySettings, [scanSettings]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.applySettings, [scanSettings]);
   }
 
   finishOnScanCallback(session) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.finishOnScanCallback,
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.finishOnScanCallback,
       session);
   }
-  
+
   finishOnRecognizeNewCodes(session) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.finishOnRecognizeNewCodes,
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.finishOnRecognizeNewCodes,
       session);
   }
 
   setBeepEnabled(isEnabled) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setBeepEnabled, [isEnabled]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setBeepEnabled, [isEnabled]);
   }
 
   setVibrateEnabled(isEnabled) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setVibrateEnabled, [isEnabled]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setVibrateEnabled, [isEnabled]);
   }
 
   setTorchEnabled(isEnabled) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setTorchEnabled, [isEnabled]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setTorchEnabled, [isEnabled]);
   }
 
   setCameraSwitchVisibility(visibility) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setCameraSwitchVisibility, [visibility]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setCameraSwitchVisibility, [visibility]);
   }
 
   setTextRecognitionSwitchVisible(isVisible) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setTextRecognitionSwitchVisible, [isVisible]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setTextRecognitionSwitchVisible, [isVisible]);
   }
 
   setViewfinderDimension(x, y, width, height) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setViewfinderDimension, [x, y, width, height]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setViewfinderDimension, [x, y, width, height]);
   }
 
   setTorchButtonMarginsAndSize(leftMargin, topMargin, width, height) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setTorchButtonMarginsAndSize, [leftMargin, topMargin, width, height]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setTorchButtonMarginsAndSize, [leftMargin, topMargin, width, height]);
   }
 
   setCameraSwitchMarginsAndSize(leftMargin, topMargin, width, height) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setCameraSwitchMarginsAndSize, [leftMargin, topMargin, width, height]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setCameraSwitchMarginsAndSize, [leftMargin, topMargin, width, height]);
   }
 
   setViewfinderColor(color) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setViewfinderColor, [color]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setViewfinderColor, [color]);
   }
 
   setViewfinderDecodedColor(color) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setViewfinderDecodedColor, [color]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setViewfinderDecodedColor, [color]);
   }
 
   setMatrixScanHighlightingColor(state, color) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setMatrixScanHighlightingColor, [state, color]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setMatrixScanHighlightingColor, [state, color]);
   }
 
   setOverlayProperty(propName, propValue) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setOverlayProperty, [propName, propValue]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setOverlayProperty, [propName, propValue]);
   }
 
   setGuiStyle(style) {
     UIManager.dispatchViewManagerCommand(
       this.pickerViewHandle,
-      UIManager.BarcodePicker.Commands.setGuiStyle, [style]);
+      UIManager.getViewManagerConfig('BarcodePicker').Commands.setGuiStyle, [style]);
   }
 
 }


### PR DESCRIPTION
**Issue**
React Native 0.58 deprecated support for directly accessing view manager via UIManager['XYZ']. See screenshot below.
![screenshot](https://user-images.githubusercontent.com/8375739/53194979-48152a00-35da-11e9-884e-1af30cde3101.png)

**Fix**
Access 'BarcodePicker' via UIManager.getViewManagerConfig as recommended in the warning message.
