### PR TITLE
'Too much glare' and 'Not enough contrast' can be now registered with…

### DIFF
--- a/android/src/main/java/com/scandit/reactnative/BridgeHelpers.kt
+++ b/android/src/main/java/com/scandit/reactnative/BridgeHelpers.kt
@@ -48,6 +48,16 @@ fun newlyTrackedCodesToMap(codes: List<TrackedBarcode>): WritableMap {
     return event
 }
 
+fun warningsToMap(warnings: Set<Int>): WritableMap {
+    val event = Arguments.createMap()
+
+    val warningsArray = Arguments.createArray()
+    warnings.forEach { warningsArray.pushInt(it) }
+    event.putArray("warnings", warningsArray)
+
+    return event
+}
+
 fun barcodeToMap(barcode: Barcode?, index: Int = -1): WritableMap {
     val map = barcodeToMap(barcode)
 

--- a/components/BarcodePicker.js
+++ b/components/BarcodePicker.js
@@ -23,6 +23,7 @@ var iface = {
         onBarcodeFrameAvailable: PropTypes.func,
         onSettingsApplied: PropTypes.func,
         onTextRecognized: PropTypes.func,
+        onWarnings: PropTypes.func,
         ...View.propTypes
   }
 };
@@ -38,6 +39,7 @@ export class BarcodePicker extends React.Component {
         this.onBarcodeFrameAvailable = this.onBarcodeFrameAvailable.bind(this);
         this.onSettingsApplied = this.onSettingsApplied.bind(this);
         this.onTextRecognized = this.onTextRecognized.bind(this);
+        this.onWarnings = this.onWarnings.bind(this);
     }
 
     componentDidMount() {
@@ -84,6 +86,13 @@ export class BarcodePicker extends React.Component {
         this.props.onTextRecognized(event.nativeEvent.text);
     }
 
+    onWarnings(event: Event) {
+        if (!this.props.onWarnings) {
+            return
+        }
+        this.props.onWarnings(event.nativeEvent);
+    }
+
     render() {
         return <ReactBarcodePicker
             {...this.props}
@@ -92,6 +101,7 @@ export class BarcodePicker extends React.Component {
             onBarcodeFrameAvailable = {this.onBarcodeFrameAvailable}
             onSettingsApplied = {this.onSettingsApplied}
             onTextRecognized = {this.onTextRecognized}
+            onWarnings = {this.onWarnings}
             ref = {(scan) => {this.reference = scan}} />;
     }
 
@@ -167,4 +177,9 @@ export class BarcodePicker extends React.Component {
         this.dispatcher.setGuiStyle(style);
     }
 
+}
+
+BarcodePicker.Warning = {
+    TOO_MUCH_GLARE_WARNING: 3,
+    NOT_ENOUGH_CONTRAST_WARNING: 4
 }

--- a/docs/Scandit.java
+++ b/docs/Scandit.java
@@ -71,7 +71,7 @@ public class Scandit {
     /**
     * @brief An enumeration of all supported barcode symbologies
     */
-    public enum Symbology  {
+    public enum Symbology {
 
       /**
       * @brief Sentinel value to represent an unknown symbology
@@ -318,6 +318,14 @@ public class Scandit {
     public function onTextRecognized;
 
     /**
+     *  @brief Prop used to set the a warnings callback.
+     *
+     *  The onWarnings method will be executed after every time a warning is raised
+     *  by the frame processing engine.
+     */
+    public function onWarnings;
+
+    /**
     * @brief Reconfigure the barcode picker with new settings
     *
     * The settings are applied asynchronously. Once they have been applied, all new frames
@@ -529,6 +537,22 @@ public class Scandit {
     */
     public void setOverlayProperty(String key, Object value);
     ///@}
+
+    /**
+     * @brief Warnings that can be raised by the frame processing engine.
+     */
+    public enum Warning {
+
+      /**
+       * @brief Too much glare warning.
+       */
+      TOO_MUCH_GLARE_WARNING,
+      /**
+       * @brief Not enough contrast warning.
+       */
+      NOT_ENOUGH_CONTRAST_WARNING
+    }
+
   }
 
   /**


### PR DESCRIPTION
…… (#115)

* 'Too much glare' and 'Not enough contrast' can be now registered with the BarcodePicker's WarningsListener.

* Warning enum added.

* Warning enum added - minor fix.

* Documentation added.

(cherry picked from commit 67c433061c7a81d4c5b16845708d67adaeea63d6)