### PR TITLE
cherry pick: do not remove self as warnings observer in dealloc

### DIFF
--- a/ios/ScanditBarcodeScanner/SCNBarcodePicker.m
+++ b/ios/ScanditBarcodeScanner/SCNBarcodePicker.m
@@ -197,7 +197,6 @@ static inline NSString *base64StringFromFrame(CMSampleBufferRef *frame) {
 }
 
 - (void)dealloc {
-    [_picker removeWarningsObserver:self];
     [_picker removePropertyObserver:self];
 }
 


### PR DESCRIPTION
Signed-off-by: Petra Donka <petra@scandit.com>
