### PR TITLE
SDK-10835 bubbling direct events

### DIFF
--- a/ios/ScanditBarcodeScanner/SCNBarcodePicker.h
+++ b/ios/ScanditBarcodeScanner/SCNBarcodePicker.h
@@ -17,13 +17,13 @@
 
 @property (nonatomic, strong, nullable) NSDictionary *scanSettings;
 @property (nonatomic) BOOL shouldPassBarcodeFrame;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onScan;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onBarcodeFrameAvailable;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onRecognizeNewCodes;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onTextRecognized;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onSettingsApplied;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onWarnings;
-@property (nonatomic, copy, nullable) RCTBubblingEventBlock onPropertyChanged;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onScan;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onBarcodeFrameAvailable;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onRecognizeNewCodes;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onTextRecognized;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onSettingsApplied;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onWarnings;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onPropertyChanged;
 
 - (void)finishOnScanCallbackShouldStop:(BOOL)shouldStop
                            shouldPause:(BOOL)shouldPause

--- a/ios/ScanditBarcodeScanner/SCNBarcodePickerManager.m
+++ b/ios/ScanditBarcodeScanner/SCNBarcodePickerManager.m
@@ -31,13 +31,13 @@ RCT_EXPORT_MODULE(BarcodePicker)
 
 RCT_EXPORT_VIEW_PROPERTY(scanSettings, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(shouldPassBarcodeFrame, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(onScan, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onRecognizeNewCodes, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onBarcodeFrameAvailable, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onTextRecognized, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onSettingsApplied, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onWarnings, RCTBubblingEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onPropertyChanged, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onScan, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onRecognizeNewCodes, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onBarcodeFrameAvailable, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTextRecognized, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onSettingsApplied, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onWarnings, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPropertyChanged, RCTDirectEventBlock)
 
 RCT_EXPORT_METHOD(startScanning:(nonnull NSNumber *)reactTag) {
     [self.bridge.uiManager addUIBlock:


### PR DESCRIPTION
Signed-off-by: Petra Donka <petra@scandit.com>

This is to solve https://github.com/Scandit/barcodescanner-sdk-react-native/issues/145 - there's barely any documentation on the difference of these 2 events, the most I found is:

> Notes: Bubbling events are like DOM events so that a parent component can capture an event fired by its child. Generally these are UI-related, like "the user touched this box". Direct events are not bubbled and are intended for more abstract events like "this image failed to load".

from https://gist.github.com/chourobin/f83f3b3a6fd2053fad29fff69524f91c

Changing this shouldn't have any negative consequences. I tried the SimpleSample and it worked with this change.

_Needs to be cherry-picked to 5.11_