### PR TITLE
[SDC-2313] Fix deadlock caused by JS callback not being called when scanner stopped/paused from the JS side

### DIFF
--- a/ios/ScanditBarcodeScanner/SCNBarcodePicker.h
+++ b/ios/ScanditBarcodeScanner/SCNBarcodePicker.h
@@ -26,6 +26,9 @@
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onWarnings;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onPropertyChanged;
 
+- (void)pauseScanning;
+- (void)stopScanning;
+
 - (void)finishOnScanCallbackShouldStop:(BOOL)shouldStop
                            shouldPause:(BOOL)shouldPause
                          codesToReject:(nullable NSArray<NSNumber *> *)codesToReject;

--- a/ios/ScanditBarcodeScanner/SCNBarcodePickerManager.m
+++ b/ios/ScanditBarcodeScanner/SCNBarcodePickerManager.m
@@ -71,7 +71,7 @@ RCT_EXPORT_METHOD(stopScanning:(nonnull NSNumber *)reactTag) {
          if (![view isKindOfClass:[SCNBarcodePicker class]]) {
              RCTLogError(@"Invalid view returned from registry, expecting SCNBarcodePicker, got: %@", view);
          } else {
-             [((SCNBarcodePicker *)view).picker stopScanning];
+             [((SCNBarcodePicker *)view) stopScanning];
          }
      }];
 }
@@ -83,7 +83,7 @@ RCT_EXPORT_METHOD(pauseScanning:(nonnull NSNumber *)reactTag) {
          if (![view isKindOfClass:[SCNBarcodePicker class]]) {
              RCTLogError(@"Invalid view returned from registry, expecting SCNBarcodePicker, got: %@", view);
          } else {
-             [((SCNBarcodePicker *)view).picker pauseScanning];
+             [((SCNBarcodePicker *)view) pauseScanning];
          }
      }];
 }


### PR DESCRIPTION
It's possible that we are requested to stop/pause the picker while we are waiting for a callback from the JS side. When the JS side asks to stop/pause the picker, this callback is not executed and the signal is not sent to the semaphore. This means that the session queue, that is waiting for the semaphore, will just wait forever. Here by signaling the semaphores, we make sure that the session queue is not blocked and it will finish the code it has to execute.