### PR TITLE
[SDC-2605] removed extension constants from docs

### DIFF
--- a/components/SymbologySettings.js
+++ b/components/SymbologySettings.js
@@ -17,6 +17,7 @@ SymbologySettings.Checksum = {
     MOD_1110: "mod1110"
 }
 
+// Removed from documentation as they are/can be passed simply as strings.
 SymbologySettings.Extension = {
     FULL_ASCII: "full_ascii",
     REMOVE_LEADING_ZERO: "remove_leading_zero",

--- a/docs/Scandit.java
+++ b/docs/Scandit.java
@@ -1119,45 +1119,6 @@ public class Scandit {
     }
 
     /**
-    * Extensions for the symbology.
-    */
-    public enum Extension {
-
-      /**
-      * Interprets the Code39 code data using two symbols per output character to encode all ASCII characters.
-      */
-      FULL_ASCII,
-
-      /**
-      * Removes the leading zero digit from the result.
-      */
-      REMOVE_LEADING_ZERO,
-
-      /**
-      * Enables scanning codes that have quiet zones (white area before and after the code) that are significantly
-      * smaller than allowed by the symbology specification. Use this extension if you are having difficulties to
-      * scan codes due to quiet zone violations. However, enabling it may come at the cost of more false positives
-      * under certain circumstances.
-      */
-      RELAXED_SHARP_QUIET_ZONE_CHECK,
-
-      /**
-      * Transforms the UPCE result into its UPCA representation.
-      */
-      RETURN_AS_UPCA,
-
-      /**
-      * Removes the leading zero digit from the result if the UPCA representation extension 'return_as_upca' is enabled.
-      */
-      REMOVE_LEADING_UPCA_ZERO,
-
-      /**
-      * Removes the leading FNC1 character that indicates a GS1 code.
-      */
-      STRIP_LEADING_FNC1
-    }
-
-    /**
     * Enables/disables decoding of dark codes on bright background only. If color-
     * inverted (bright on dark) codes for this symbology are required, enable them through the
     * colorInvertedEnabled property. By default decoding of all symbologies is disabled.
@@ -1180,9 +1141,9 @@ public class Scandit {
     * An array of all active custom extensions for the symbology.
     *
     * Extensions are custom features that are only supported by a small number of
-    * symbologies. For a list of supported extensions, consult the constants of this class.
+    * symbologies. For a list of supported extensions, consult <a href="../c_api/symbologies.html">.
     */
-    public Extension[] extensions;
+    public String[] extensions;
 
     /**
     * Array of additional checksums for this symbology. When a barcode has been


### PR DESCRIPTION
extensions can be simply passed as strings. the enum was completely outdated and unnecessary and had to be maintained.

the old extension constant is still there, so nothing changes for anyone still using this, it'll keep working as before.