### PR TITLE
The Map.forEach loop with 2 arguments (key and value) was crashing

### DIFF
--- a/android/src/main/java/com/scandit/reactnative/BridgeHelpers.kt
+++ b/android/src/main/java/com/scandit/reactnative/BridgeHelpers.kt
@@ -59,7 +59,7 @@ private fun trackedBarcodesToArray(
 ): WritableArray {
     val array = Arguments.createArray()
 
-    codes.forEach { id, barcode ->
+    codes.forEach { (id, barcode) ->
         val codeMap = barcodeToMap(barcode, id)
         codeMap.putInt("deltaTimeForPrediction", barcode.deltaTimeForPrediction.toInt())
         codeMap.putBoolean("shouldAnimateFromPreviousToNextState", barcode.shouldAnimateFromPreviousToNextState())


### PR DESCRIPTION
 with NoClassDefFoundError exception on devices with older android OS version, as the method was not available in android at runtime. Replaced with Map.forEach with a single argument.