### PR TITLE
If a BarcodePicker's listener callback hadn't returned from JS back t…

### DIFF
--- a/android/src/main/java/com/scandit/reactnative/BarcodePicker.kt
+++ b/android/src/main/java/com/scandit/reactnative/BarcodePicker.kt
@@ -88,6 +88,11 @@ class BarcodePicker(
                 // Run stopping of the picker on a non-UI thread, to avoid a deadlock.
                 Thread(object : Runnable {
                     override fun run() {
+                        finishOnScan(null)
+                        finishOnRecognizeNewCodes(null)
+                        finishOnChangeTrackedCodes(null)
+                        finishOnTextRecognized(null)
+
                         root.stopScanning()
                     }
                 }).start()


### PR DESCRIPTION
…o Native before stopScanning was called, a deadlock would happen, resulting in a black camera preview once the BarcodePicker is restarted. The deadlock can be avoided by making sure no engine threads are waiting on a latch, right before stopScanning is called. (#220)

Co-authored-by: Tomek Jurkowski <tomasz@scandit.com>
(cherry picked from commit 843137904b659a9385a70d58f8af5f7cdb21d694)